### PR TITLE
release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,21 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2025-02-02
+### Added
+
+- Show the selected and suggested columns for the `order` operation
+
 ### Fixed
+
 - The graph was not being showing on modifying the expression that just ran.
+- The graph was not being shown when a printable character was pressed.
+- Sidebar width for smaller screens i.e. adjust the width when the dev console is opened
 
 ## [0.11.0] - 2025-01-11
+
 ### Added
+
 - Arranged the layout so that the graph can take more space
 
 ### Fixed

--- a/components/SelectedNodeComponent.tsx
+++ b/components/SelectedNodeComponent.tsx
@@ -124,6 +124,7 @@ const SelectedColumns = ({ columns }: { columns: string[] }) => (
     style={{
       maxHeight: '500px',
       overflow: 'hidden',
+      flex: 1,
     }}
   >
     <div
@@ -131,7 +132,6 @@ const SelectedColumns = ({ columns }: { columns: string[] }) => (
         display: 'flex',
         flexWrap: 'wrap',
         gap: '4px',
-        justifyContent: 'center',
       }}
     >
       {columns.map(column => (
@@ -190,11 +190,18 @@ const CandidateColumns = ({ columns }: { columns: string[] }) => (
   </div>
 );
 
-const Columns = ({ columns, suggested }: { columns: string[]; suggested: string[] }) => {
-  const selectedColumnsSet = new Set(columns);
-  const candidateColumns = suggested.filter(
-    col => !selectedColumnsSet.has(col),
-  );
+const Columns = ({
+  columns,
+  suggested,
+  type,
+}: {
+  columns: string[];
+  suggested: string[];
+  type: 'select' | 'order';
+}) => {
+  const selectedColumnsSet = new Set(columns.filter(Boolean));
+  const candidateColumns = suggested.filter(col => !selectedColumnsSet.has(col));
+  const showOperationName = selectedColumnsSet.size > 0 || candidateColumns.length > 0;
 
   return (
     <div
@@ -202,29 +209,60 @@ const Columns = ({ columns, suggested }: { columns: string[]; suggested: string[
         width: 200,
         display: 'flex',
         flexDirection: 'column',
-        gap: '8px',
       }}
     >
-      <SelectedColumns columns={columns} />
-      <CandidateColumns columns={candidateColumns} />
+      {showOperationName && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <span
+            style={{
+              fontFamily: 'Courier, monospace',
+              fontSize: '8px',
+              color: '#666',
+              whiteSpace: 'nowrap',
+              fontWeight: 'bold',
+            }}
+          >
+            {type.charAt(0)}:
+          </span>
+          {selectedColumnsSet.size > 0 && (
+            <SelectedColumns columns={Array.from(selectedColumnsSet)} />
+          )}
+        </div>
+      )}
+      {candidateColumns.length > 0 && (
+        <div
+          style={{
+            border: '1px solid #eee',
+            borderRadius: '8px',
+            borderColor: '#eee',
+            padding: '12px',
+            margin: '8px',
+          }}
+        >
+          <CandidateColumns columns={candidateColumns} />
+        </div>
+      )}
     </div>
   );
 };
 
 const SelectedNodeComponent: React.FC<PineNodeProps> = ({ data }) => {
-  const { order, table, schema, color, alias, columns, suggestedColumns } = data;
-  const showBorder = suggestedColumns.length > 0;
+  const {
+    order,
+    table,
+    schema,
+    color,
+    alias,
+    columns: selectedColumns,
+    orderColumns,
+    suggestedColumns,
+    suggestedOrderColumns,
+  } = data;
   return (
-    <div
-      style={{
-        border: '1px solid #ccc',
-        borderRadius: showBorder ? '8px' : '0',
-        borderColor: showBorder ? '#ccc' : 'transparent',
-        padding: '12px',
-      }}
-    >
+    <div>
       <TableNode order={order} table={table} schema={schema} color={color} alias={alias} />
-      <Columns columns={columns} suggested={suggestedColumns} />
+      <Columns columns={selectedColumns} suggested={suggestedColumns} type="select" />
+      <Columns columns={orderColumns} suggested={suggestedOrderColumns} type="order" />
     </div>
   );
 };

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -62,10 +62,10 @@ const Session: React.FC<SessionProps> = observer(({ sessionId }) => {
   return (
     <Grid container>
       <Grid container sx={{ mt: 2, height: 'calc(100vh - 122px)' }}>
-        <Grid item xs={2}>
+        <Grid item xs={4} md={3} lg={2}>
           <Sidebar sessionId={sessionId} />
         </Grid>
-        <Grid item xs={10}>
+        <Grid item xs={8} md={9} lg={10}>
           <MainView
             sessionId={sessionId}
             loaded={session.loaded}

--- a/model.d.ts
+++ b/model.d.ts
@@ -12,8 +12,10 @@ export type SelectedNodeData = BaseNode & {
   alias: string;
   order: number;
   columns: string[];
+  orderColumns: string[];
   // Current node
   suggestedColumns: string[];
+  suggestedOrderColumns: string[];
 };
 
 export type SuggestedNodeData = BaseNode & {

--- a/store/client.ts
+++ b/store/client.ts
@@ -14,9 +14,11 @@ export type ColumnHint = {
   alias: string;
 };
 
-export type Hints = { table: TableHint[]; select: ColumnHint[] };
+export type Hints = { table: TableHint[]; select: ColumnHint[]; order: ColumnHint[] };
 // There are more operations. I'll add them as we need to handle them here
-export type Operation = { type: 'table' | 'delete' | 'select-partial' };
+export type Operation = {
+  type: 'table' | 'delete' | 'select' | 'select-partial' | 'order' | 'order-partial';
+};
 export type Column = { column: string; alias: string };
 
 export type Ast = {
@@ -27,6 +29,7 @@ export type Ast = {
   current: string;
   operation: Operation;
   columns: Column[];
+  order: Column[];
 };
 
 export type Response = {

--- a/store/global.store.ts
+++ b/store/global.store.ts
@@ -3,7 +3,7 @@ import { lt } from 'semver';
 import { HttpClient } from './client';
 import { Session } from './session';
 
-const requiredVersion = '0.14.1';
+const requiredVersion = '0.15.0';
 
 const initSession = new Session('0');
 

--- a/store/session.ts
+++ b/store/session.ts
@@ -99,7 +99,6 @@ export class Session {
   constructor(id: string) {
     this.id = `session-${id}`;
 
-    // TODO: explicitly mark the observables, actions, computables
     makeAutoObservable(this);
 
     // Evaluation plugins
@@ -124,7 +123,7 @@ export class Session {
         } catch (e) {
           this.error = (e as any).message || 'Failed to build';
         }
-      }, 150),
+      }, 200),
     );
 
     /**


### PR DESCRIPTION
### Added

- Show the selected and suggested columns for the `order` operation

### Fixed

- The graph was not being showing on modifying the expression that just ran.
- The graph was not being shown when a printable character was pressed.
- Sidebar width for smaller screens i.e. adjust the width when the dev console is opened