### PR TITLE
Release 0.42.0: per-session connections with color indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-05-05
+### Added
+- Per-session database connections: each tab can connect to a different database. Queries from that tab always use its own connection.
+- Connection color indicators: each database connection gets a distinct color (green, red, blue, orange, purple, teal, pink, yellow) shown as a dot in the header and tab bar. Click the dot to pick a different color. Colors persist across page refreshes.
+
 ## [0.41.0] - 2026-05-04
 ### Added
 - Command palette entries to copy the current Pine expression and the current SQL.

--- a/components/ActiveConnection.tsx
+++ b/components/ActiveConnection.tsx
@@ -1,35 +1,98 @@
-import { Box, Typography } from '@mui/material';
+import { Box, ClickAwayListener, Typography } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useState } from 'react';
 import { useStores } from '../store/store-container';
+import { CONNECTION_COLOR_PALETTE } from '../store/util';
 import Settings from '../pages/settings';
+
 const ActiveConnection = () => {
   const { global } = useStores();
-  const [connectionDisplay, setConnectionDisplay] = useState('🔌 No connection!');
+  const [showColorPicker, setShowColorPicker] = useState(false);
+
+  const activeSession = global.sessions[global.activeSessionId];
+  const connectionId = activeSession?.connectionId || global.connection;
+  const connectionColor = global.getConnectionColor(connectionId);
+  const isDbConnected = !!connectionId;
 
   useEffect(() => {
-    if (!global.pineConnected) {
-      setConnectionDisplay('🔌 No connection to Pine server!');
-      return;
-    }
-
-    const serverVersion = global.version ?? 'obsolete';
-    const dbConnectionName = global.getConnectionName();
-    const status = global.dbConnected ? '⚡' : '🔌';
-
-    setConnectionDisplay(
-      `${status} [${serverVersion}] ${dbConnectionName || 'Not connected to database'}`,
-    );
-
-    // Show the database connection settings if no database is connected
-    if (!global.dbConnected) {
+    if (global.pineConnected && !isDbConnected) {
       global.setShowSettings(true);
     }
-  }, [global, global.pineConnected, global.dbConnected, global.version, global.connection]);
+  }, [global.pineConnected, isDbConnected]);
+
+  const serverVersion = global.version ?? 'obsolete';
+  const displayName = connectionId
+    ? connectionId.length > 24
+      ? connectionId.substring(0, 24) + '...'
+      : connectionId
+    : 'Not connected to database';
+  const status = isDbConnected ? '⚡' : '🔌';
+
+  const displayText = global.pineConnected
+    ? `${status} [${serverVersion}] ${displayName}`
+    : '🔌 No connection to Pine server!';
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
       {global.showSettings && <Settings />}
+      {connectionId && (
+        <ClickAwayListener onClickAway={() => setShowColorPicker(false)}>
+          <Box sx={{ position: 'relative' }}>
+            <Box
+              onClick={() => setShowColorPicker(v => !v)}
+              sx={{
+                width: 10,
+                height: 10,
+                borderRadius: '50%',
+                backgroundColor: connectionColor,
+                flexShrink: 0,
+                cursor: 'pointer',
+                transition: 'opacity 0.15s',
+                '&:hover': { opacity: 0.75 },
+              }}
+            />
+            {showColorPicker && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 14,
+                  left: 0,
+                  zIndex: 1000,
+                  backgroundColor: 'var(--background-color)',
+                  border: '1px solid var(--border-color)',
+                  borderRadius: 1,
+                  p: 0.75,
+                  display: 'flex',
+                  gap: 0.75,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                }}
+              >
+                {CONNECTION_COLOR_PALETTE.map(color => (
+                  <Box
+                    key={color}
+                    onClick={() => {
+                      global.setConnectionColor(connectionId, color);
+                      setShowColorPicker(false);
+                    }}
+                    sx={{
+                      width: 18,
+                      height: 18,
+                      borderRadius: '50%',
+                      backgroundColor: color,
+                      cursor: 'pointer',
+                      border: color === connectionColor
+                        ? '2px solid var(--text-color)'
+                        : '2px solid transparent',
+                      transition: 'transform 0.1s',
+                      '&:hover': { transform: 'scale(1.25)' },
+                    }}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
+        </ClickAwayListener>
+      )}
       <Typography
         variant="caption"
         component="code"
@@ -39,7 +102,7 @@ const ActiveConnection = () => {
           style: { cursor: 'pointer' },
         })}
       >
-        {connectionDisplay}
+        {displayText}
       </Typography>
     </Box>
   );

--- a/components/PineTabs.tsx
+++ b/components/PineTabs.tsx
@@ -55,16 +55,30 @@ const PineTabs = observer(() => {
           >
             {tabs.map((tab, index) => {
               const session = global.getSession(tab.sessionId);
+              const sessionConnectionId = session.connectionId || global.connection;
+              const connectionColor = global.getConnectionColor(sessionConnectionId);
               return (
                 <Tab
                   key={tab.sessionId}
                   tabIndex={-1} // Prevent tab focus
                   label={
                     <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      {sessionConnectionId && (
+                        <span
+                          style={{
+                            width: 6,
+                            height: 6,
+                            borderRadius: '50%',
+                            backgroundColor: connectionColor,
+                            display: 'inline-block',
+                            flexShrink: 0,
+                          }}
+                        />
+                      )}
                       {session.loading && (
-                        <CircularProgress 
-                          size={12} 
-                          sx={{ color: 'inherit' }} 
+                        <CircularProgress
+                          size={12}
+                          sx={{ color: 'inherit' }}
                         />
                       )}
                       {global.getSessionName(tab.sessionId)}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/plugin/default.plugin.tsx
+++ b/plugin/default.plugin.tsx
@@ -18,8 +18,8 @@ export class DefaultPlugin implements PluginInterface {
     // Use SQL endpoint if in SQL mode, otherwise use Pine eval endpoint
     const response =
       session.inputMode === 'sql'
-        ? await this.client.sql(session.query)
-        : await this.client.eval(session.expression);
+        ? await this.client.sql(session.query, session.connectionId)
+        : await this.client.eval(session.expression, session.connectionId);
 
     if (!response) {
       session.message = '🤷 No response';

--- a/plugin/recursive-delete.plugin.ts
+++ b/plugin/recursive-delete.plugin.ts
@@ -66,22 +66,22 @@ export class RecursiveDeletePlugin implements PluginInterface {
     column: string,
     deleteQueries: string[],
   ): Promise<void> {
-    await this.client.build(expression);
-    const count = await this.client.count(expression);
+    await this.client.build(expression, undefined, this.session.connectionId);
+    const count = await this.client.count(expression, this.session.connectionId);
 
     if (count === 0) {
       return;
     }
 
     // Recurse to process children first
-    const { expressions } = await this.client.makeChildExpressions(expression);
+    const { expressions } = await this.client.makeChildExpressions(expression, this.session.connectionId);
 
     for (const { expression: childExpression, column: childColumn } of expressions) {
       await this.collectDeleteQueries(childExpression, childColumn, deleteQueries);
     }
 
     // After processing children, add the delete query for the current expression
-    const query = await this.client.buildDeleteQuery(expression, column, count);
+    const query = await this.client.buildDeleteQuery(expression, column, count, this.session.connectionId);
     deleteQueries.push(`/*\n${expression}\n*/`);
     deleteQueries.push(query);
   }

--- a/store/client.ts
+++ b/store/client.ts
@@ -137,8 +137,15 @@ export class HttpClient {
     return await res.json();
   }
 
-  public async prettify(expression: string): Promise<string> {
-    const response: Response | undefined = await this.post('build', { expression });
+  private withConnectionId(body: object, connectionId?: string): object {
+    if (connectionId) {
+      return { ...body, 'connection-id': connectionId };
+    }
+    return body;
+  }
+
+  public async prettify(expression: string, connectionId?: string): Promise<string> {
+    const response: Response | undefined = await this.post('build', this.withConnectionId({ expression }, connectionId));
     if (!response) {
       throw new Error('No response when trying to prettify');
     }
@@ -148,28 +155,28 @@ export class HttpClient {
     return response.ast.prettified;
   }
 
-  public async eval(expression: string): Promise<Response> {
-    const response = await this.post('eval', { expression });
+  public async eval(expression: string, connectionId?: string): Promise<Response> {
+    const response = await this.post('eval', this.withConnectionId({ expression }, connectionId));
     if (!response) {
       throw new Error('No response when trying to eval');
     }
     return response;
   }
 
-  public async sql(query: string): Promise<Response> {
-    const response = await this.post('sql', { query: query.trim() });
+  public async sql(query: string, connectionId?: string): Promise<Response> {
+    const response = await this.post('sql', this.withConnectionId({ query: query.trim() }, connectionId));
     if (!response) {
       throw new Error('No response when trying to execute SQL');
     }
     return response;
   }
 
-  public async build(expression: string, cursor?: CursorPosition): Promise<Response> {
+  public async build(expression: string, cursor?: CursorPosition, connectionId?: string): Promise<Response> {
     const body: { expression: string; cursor?: CursorPosition } = { expression };
     if (cursor) {
       body.cursor = cursor;
     }
-    const response = await this.post('build', body);
+    const response = await this.post('build', this.withConnectionId(body, connectionId));
     if (!response) {
       throw new Error('No response when trying to build');
     }
@@ -177,8 +184,8 @@ export class HttpClient {
     return response;
   }
 
-  public async count(expression: string): Promise<number> {
-    const response = await this.eval(`${expression} | count:`);
+  public async count(expression: string, connectionId?: string): Promise<number> {
+    const response = await this.eval(`${expression} | count:`, connectionId);
     if (!response) {
       throw new Error('No respnse when trying to count');
     }
@@ -190,10 +197,11 @@ export class HttpClient {
 
   public async makeChildExpressions(
     expression: string,
+    connectionId?: string,
   ): Promise<{ expressions: { expression: string; column: string }[]; ast: Ast }> {
     // Add trailing `|` explicitly for child expressions
     const x = `${expression} |`;
-    const response = await this.post('build', { expression: x });
+    const response = await this.post('build', this.withConnectionId({ expression: x }, connectionId));
     if (!response) {
       throw new Error('No response when trying to make child Expressions');
     }
@@ -211,9 +219,10 @@ export class HttpClient {
     expression: string,
     column: string,
     limit: number,
+    connectionId?: string,
   ): Promise<string> {
     const x = `${expression} | limit: ${limit} | delete! .${column}`;
-    const response = await this.build(x);
+    const response = await this.build(x, undefined, connectionId);
     if (!response) {
       throw new Error('No response when trying to build the delete query');
     }

--- a/store/global.store.ts
+++ b/store/global.store.ts
@@ -6,6 +6,7 @@ import { RequiredVersion } from '../constants';
 import { getUserPreference, setUserPreference, STORAGE_KEYS } from './preferences';
 import { DevState } from './dev-state';
 import { getCommandById } from '../utils/commands';
+import { CONNECTION_COLOR_PALETTE } from './util';
 
 const client = new HttpClient();
 type ConnectionParams = {
@@ -21,13 +22,16 @@ export class GlobalStore {
   connection = '';
   version: string | undefined = undefined;
   requiresUpgrade = false;
+  connectionColors: Record<string, string> = {};
 
   get pineConnected() {
     return DevState.pineConnected ?? !!this.version;
   }
 
   get dbConnected() {
-    return DevState.dbConnected ?? !!this.connection;
+    const activeSession = this.sessions[this.activeSessionId];
+    const connectionId = activeSession?.connectionId || this.connection;
+    return DevState.dbConnected ?? !!connectionId;
   }
 
   activeSessionId = 'session-0';
@@ -121,12 +125,31 @@ export class GlobalStore {
     this._pineTableColorsEnabled = getUserPreference(STORAGE_KEYS.PINE_TABLE_COLORS, false);
     this._onboardingServer = getUserPreference(STORAGE_KEYS.ONBOARDING_SERVER, false);
     this._commandHistory = getUserPreference(STORAGE_KEYS.COMMAND_HISTORY, []);
+    this.connectionColors = getUserPreference(STORAGE_KEYS.CONNECTION_COLORS, {});
     makeAutoObservable(this);
 
     // Initialize the default session
     const initSession = new Session('0', this);
     this.sessions[initSession.id] = initSession;
   }
+
+  getConnectionColor = (connectionId: string): string => {
+    return this.connectionColors[connectionId] ?? '';
+  };
+
+  setConnectionColor = (connectionId: string, color: string) => {
+    this.connectionColors[connectionId] = color;
+    setUserPreference(STORAGE_KEYS.CONNECTION_COLORS, this.connectionColors);
+  };
+
+  private assignConnectionColor = (connectionId: string) => {
+    if (!connectionId || this.connectionColors[connectionId]) return;
+    const used = new Set(Object.values(this.connectionColors));
+    const color =
+      CONNECTION_COLOR_PALETTE.find(c => !used.has(c)) ??
+      CONNECTION_COLOR_PALETTE[Object.keys(this.connectionColors).length % CONNECTION_COLOR_PALETTE.length];
+    this.setConnectionColor(connectionId, color);
+  };
 
   public async handleUrlParameters() {
     if (typeof window === 'undefined') return; // Skip on server-side
@@ -219,6 +242,15 @@ export class GlobalStore {
     }
     this.connection = id;
     this.version = version ?? '0.0.0';
+    this.assignConnectionColor(id);
+
+    const activeSession = this.sessions[this.activeSessionId];
+    if (activeSession) {
+      activeSession.connectionId = id;
+    }
+    if (this.virtualSession) {
+      this.virtualSession.connectionId = id;
+    }
 
     if (!this.onboardingServer) {
       this.onboardingServer = true;
@@ -228,6 +260,7 @@ export class GlobalStore {
 
   createSessionUsingId = (id: string) => {
     const session = new Session(id, this);
+    session.connectionId = this.connection;
     this.sessions[session.id] = session;
     return session;
   };
@@ -306,6 +339,18 @@ export class GlobalStore {
       };
       this.version = result.version ?? '0.0.0';
       this.connection = result['connection-id'] || '';
+      this.assignConnectionColor(this.connection);
+
+      if (this.connection) {
+        Object.values(this.sessions).forEach(session => {
+          if (!session.connectionId) {
+            session.connectionId = this.connection;
+          }
+        });
+        if (this.virtualSession && !this.virtualSession.connectionId) {
+          this.virtualSession.connectionId = this.connection;
+        }
+      }
 
       if (this.pineConnected && !this.onboardingServer) {
         this.onboardingServer = true;

--- a/store/preferences.ts
+++ b/store/preferences.ts
@@ -8,6 +8,7 @@ export const STORAGE_KEYS = {
   ONBOARDING_SERVER: 'pine-onboarding-server',
   LAST_READ_VERSION: 'pine-last-read-version',
   COMMAND_HISTORY: 'pine-command-history',
+  CONNECTION_COLORS: 'pine-connection-colors',
 } as const;
 
 export const getUserPreference = (key: string, defaultValue: any) => {

--- a/store/session.ts
+++ b/store/session.ts
@@ -78,6 +78,9 @@ export class Session {
   /** Input mode - pine or sql */
   inputMode: InputMode = 'pine';
 
+  /** Per-session database connection id */
+  connectionId: string = '';
+
   /** Database connection monitoring */
   monitor: boolean = false;
   connectionCountLogs: { time: string; count: number }[] = [];
@@ -194,7 +197,7 @@ export class Session {
 
         // response - use current cursor position (not watched, but always current)
         try {
-          this.response = await client.build(expression, this.cursorPosition);
+          this.response = await client.build(expression, this.cursorPosition, this.connectionId);
         } catch (e) {
           this.error = (e as any).message || 'Failed to build';
         }
@@ -312,7 +315,7 @@ export class Session {
     }
     parts.push(pine);
     const expression = parts.join('|');
-    const prettified = await client.prettify(expression);
+    const prettified = await client.prettify(expression, this.connectionId);
     return prettified + '\n | ';
   }
 
@@ -321,7 +324,7 @@ export class Session {
   }
 
   public async prettifyExpression(expression: string, appendPipe: boolean = false): Promise<string> {
-    const prettified = await client.prettify(expression);
+    const prettified = await client.prettify(expression, this.connectionId);
     return appendPipe ? prettified + '\n | ' : prettified;
   }
 
@@ -362,7 +365,7 @@ export class Session {
    * Similar to evaluate() but only builds without executing.
    */
   public async build(expression: string): Promise<Ast> {
-    const response = await client.build(expression, this.cursorPosition);
+    const response = await client.build(expression, this.cursorPosition, this.connectionId);
     return response.ast;
   }
 

--- a/store/util.ts
+++ b/store/util.ts
@@ -72,10 +72,21 @@ export const isDevelopment = () => {
 
 /**
  * Escapes a string for use in a SQL query
- * 
+ *
  * TODO: I am replacing the single quote with an underscore but a more robust
  * solution is needed.
  */
 export const pineEscape = (x: string) => {
   return x.replace(/'/g, "_");
-} 
+};
+
+export const CONNECTION_COLOR_PALETTE = [
+  '#4ade80', // green
+  '#f87171', // red
+  '#60a5fa', // blue
+  '#fb923c', // orange
+  '#a78bfa', // purple
+  '#2dd4bf', // teal
+  '#f472b6', // pink
+  '#facc15', // yellow
+];

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,20 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.42.0',
+    date: '2026-05-05',
+    added: [
+      {
+        description:
+          'Per-session database connections: each tab can connect to a different database. Queries from that tab always use its own connection.',
+      },
+      {
+        description:
+          'Connection color indicators: each database gets a distinct color shown in the header and tab bar. Click the dot to pick a different color. Colors are saved across sessions.',
+      },
+    ],
+  },
+  {
     version: '0.41.0',
     date: '2026-05-04',
     added: [
@@ -866,4 +880,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.41.0';
+export const LATEST_VERSION = '0.42.0';


### PR DESCRIPTION
Each tab now carries its own database connection. The connection-id is sent with every API call to `build`, `eval`, and `sql`. Falls back to the global default when unset, so existing behaviour is unchanged.

## What changed

**Connection per session**
- `Session` has a `connectionId` field that's stamped when you connect
- `HttpClient` methods all accept an optional `connectionId` and include it in the request body
- New sessions inherit the current global connection; connecting via Settings applies to the active tab only

**Color indicators**
- 8 visually distinct colors (green, red, blue, orange, purple, teal, pink, yellow)
- Auto-assigned when a connection is first seen; round-robins through unused colors
- Shown as a dot in the header and in each tab label
- Click the dot in the header to pick a different color
- Colors persist to localStorage

## Files

`store/client.ts` · `store/session.ts` · `store/global.store.ts` · `store/util.ts` · `store/preferences.ts` · `plugin/default.plugin.tsx` · `plugin/recursive-delete.plugin.ts` · `components/ActiveConnection.tsx` · `components/PineTabs.tsx`