### PR TITLE
feat: add connection picker and multi-connection tab UX

### DIFF
--- a/components/ActiveConnection.tsx
+++ b/components/ActiveConnection.tsx
@@ -29,9 +29,8 @@ const ActiveConnection = () => {
       ? connectionLabel.substring(0, 24) + '...'
       : connectionLabel
     : 'Not connected to database';
-  const displayText = global.pineConnected
-    ? `${status} ${displayName}`
-    : '🔌 No connection to Pine server!';
+
+  const displayText = global.pineConnected ? displayName : '🔌 No connection to Pine server!';
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>

--- a/components/ActiveConnection.tsx
+++ b/components/ActiveConnection.tsx
@@ -1,6 +1,7 @@
-import { Box, ClickAwayListener, Typography } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import { Box, ClickAwayListener, Divider, Menu, MenuItem, Typography } from '@mui/material';
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import { useStores } from '../store/store-container';
 import { CONNECTION_COLOR_PALETTE } from '../store/util';
 import Settings from '../pages/settings';
@@ -8,6 +9,8 @@ import Settings from '../pages/settings';
 const ActiveConnection = () => {
   const { global } = useStores();
   const [showColorPicker, setShowColorPicker] = useState(false);
+  const [connectionMenuAnchor, setConnectionMenuAnchor] = useState<null | HTMLElement>(null);
+  const [switchingConnection, setSwitchingConnection] = useState(false);
 
   const activeSession = global.sessions[global.activeSessionId];
   const connectionId = activeSession?.connectionId || global.connection;
@@ -18,18 +21,18 @@ const ActiveConnection = () => {
     if (global.pineConnected && !isDbConnected) {
       global.setShowSettings(true);
     }
-  }, [global.pineConnected, isDbConnected]);
+  }, [global, global.pineConnected, isDbConnected]);
 
-  const serverVersion = global.version ?? 'obsolete';
+  const connectionLabel = connectionId ? global.getConnectionLabel(connectionId) : '';
   const displayName = connectionId
-    ? connectionId.length > 24
-      ? connectionId.substring(0, 24) + '...'
-      : connectionId
+    ? connectionLabel.length > 24
+      ? connectionLabel.substring(0, 24) + '...'
+      : connectionLabel
     : 'Not connected to database';
   const status = isDbConnected ? '⚡' : '🔌';
 
   const displayText = global.pineConnected
-    ? `${status} [${serverVersion}] ${displayName}`
+    ? `${status} ${displayName}`
     : '🔌 No connection to Pine server!';
 
   return (
@@ -80,9 +83,10 @@ const ActiveConnection = () => {
                       borderRadius: '50%',
                       backgroundColor: color,
                       cursor: 'pointer',
-                      border: color === connectionColor
-                        ? '2px solid var(--text-color)'
-                        : '2px solid transparent',
+                      border:
+                        color === connectionColor
+                          ? '2px solid var(--text-color)'
+                          : '2px solid transparent',
                       transition: 'transform 0.1s',
                       '&:hover': { transform: 'scale(1.25)' },
                     }}
@@ -98,12 +102,101 @@ const ActiveConnection = () => {
         component="code"
         color="gray"
         {...(global.pineConnected && {
-          onClick: () => global.setShowSettings(!global.showSettings),
+          onClick: (e: MouseEvent<HTMLElement>) => {
+            setShowColorPicker(false);
+            setConnectionMenuAnchor(e.currentTarget);
+          },
           style: { cursor: 'pointer' },
         })}
       >
         {displayText}
       </Typography>
+      <Menu
+        anchorEl={connectionMenuAnchor}
+        open={Boolean(connectionMenuAnchor)}
+        onClose={() => setConnectionMenuAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            sx: {
+              minWidth: 260,
+              maxHeight: 320,
+              bgcolor: 'var(--background-color)',
+              border: '1px solid var(--border-color)',
+              color: 'var(--text-color)',
+            },
+          },
+        }}
+      >
+        {global.connections.map(({ id, label }) => (
+          <MenuItem
+            key={id}
+            selected={id === activeSession?.connectionId}
+            disabled={switchingConnection}
+            onClick={async () => {
+              if (activeSession && id === activeSession.connectionId && id === global.connection) {
+                setConnectionMenuAnchor(null);
+                return;
+              }
+              setSwitchingConnection(true);
+              try {
+                await global.selectConnection(id);
+              } finally {
+                setSwitchingConnection(false);
+                setConnectionMenuAnchor(null);
+              }
+            }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              fontFamily: 'inherit',
+              fontSize: '0.8rem',
+            }}
+          >
+            <Box
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                flexShrink: 0,
+                backgroundColor: global.getConnectionColor(id) || 'var(--border-color)',
+              }}
+            />
+            <Typography
+              component="span"
+              variant="body2"
+              sx={{
+                flex: 1,
+                fontSize: '0.75rem',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {label}
+            </Typography>
+            {id === activeSession?.connectionId ? (
+              <CheckIcon sx={{ fontSize: 16, opacity: 0.7, flexShrink: 0 }} />
+            ) : (
+              <Box sx={{ width: 16, flexShrink: 0 }} />
+            )}
+          </MenuItem>
+        ))}
+        {global.connections.length > 0 ? (
+          <Divider sx={{ borderColor: 'var(--border-color)' }} />
+        ) : null}
+        <MenuItem
+          disabled={switchingConnection}
+          onClick={() => {
+            global.setShowSettings(true);
+            setConnectionMenuAnchor(null);
+          }}
+          sx={{ fontSize: '0.85rem' }}
+        >
+          Add new connection…
+        </MenuItem>
+      </Menu>
     </Box>
   );
 };

--- a/components/AppView.tsx
+++ b/components/AppView.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Grid,
-  Typography,
-  useTheme,
-  useMediaQuery,
-  Link,
-} from '@mui/material';
+import { Box, Grid, Typography, useTheme, useMediaQuery, Link } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import { useStores } from '../store/store-container';
 import PineTabs from './PineTabs';
@@ -53,7 +46,7 @@ const AppView = observer(() => {
 
   useEffect(() => {
     setMounted(true);
-    
+
     // Check for unread updates
     const lastReadVersion = getUserPreference(STORAGE_KEYS.LAST_READ_VERSION, '0.0.0');
     const hasUpdates = compare(LATEST_VERSION, lastReadVersion) > 0;
@@ -194,12 +187,22 @@ const AppView = observer(() => {
         </Grid>
 
         <Grid item xs={3}>
-          <Box sx={{ m: 1, mt: 0, mb: 0, display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+          <Box
+            sx={{
+              m: 1,
+              mt: 0,
+              mb: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 1,
+            }}
+          >
+            <Typography variant="caption" color="gray" component="code">
+              [{global.version ?? 'obsolete'}]
+            </Typography>
             {UserContent}
-            <NotificationBell
-              hasUnreadUpdates={hasUnreadUpdates}
-              onClick={handleOpenChangelog}
-            />
+            <NotificationBell hasUnreadUpdates={hasUnreadUpdates} onClick={handleOpenChangelog} />
           </Box>
         </Grid>
       </Grid>

--- a/components/PineTabs.tsx
+++ b/components/PineTabs.tsx
@@ -12,10 +12,14 @@ import { IconButton, CircularProgress } from '@mui/material';
 
 const PineTabs = observer(() => {
   const { global } = useStores();
-  
+
   // Derive tabs directly from global sessions
   const tabs = Object.keys(global.sessions).map(sessionId => ({ sessionId }));
   const sessionId = global.activeSessionId;
+  const activeSession = global.sessions[sessionId];
+  const activeConnectionId = activeSession?.connectionId || global.connection;
+  const activeIndicatorColor =
+    global.getConnectionColor(activeConnectionId) || 'var(--border-color)';
 
   const setActiveTab = (newSessionId: string) => {
     global.activeSessionId = newSessionId;
@@ -37,9 +41,15 @@ const PineTabs = observer(() => {
     <Box sx={{ width: '100%', mt: 0, pt: 0 }}>
       <TabContext value={sessionId}>
         <Box
-          sx={{ borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', mt: 0 }}
+          sx={{
+            borderBottom: 1,
+            borderColor: 'divider',
+            display: 'flex',
+            alignItems: 'center',
+            mt: 0,
+          }}
         >
-          <TabList 
+          <TabList
             onChange={handleChange}
             sx={{
               '& .MuiTab-root': {
@@ -49,7 +59,7 @@ const PineTabs = observer(() => {
                 },
               },
               '& .MuiTabs-indicator': {
-                backgroundColor: 'var(--primary-color)',
+                backgroundColor: activeIndicatorColor,
               },
             }}
           >
@@ -75,12 +85,7 @@ const PineTabs = observer(() => {
                           }}
                         />
                       )}
-                      {session.loading && (
-                        <CircularProgress
-                          size={12}
-                          sx={{ color: 'inherit' }}
-                        />
-                      )}
+                      {session.loading && <CircularProgress size={12} sx={{ color: 'inherit' }} />}
                       {global.getSessionName(tab.sessionId)}
                       <IconButton
                         style={{ marginLeft: '5px' }}
@@ -110,16 +115,16 @@ const PineTabs = observer(() => {
           </TabList>
 
           {/* Button to add new tab */}
-          <AddCircle 
-            sx={{ 
-              ml: 2, 
+          <AddCircle
+            sx={{
+              ml: 2,
               cursor: 'pointer',
               color: 'var(--primary-color)',
               '&:hover': {
                 color: 'var(--primary-color-hover)',
               },
-            }} 
-            onClick={addTab} 
+            }}
+            onClick={addTab}
           />
         </Box>
 

--- a/store/client.ts
+++ b/store/client.ts
@@ -20,7 +20,7 @@ export type ColumnHint = {
 };
 
 export type CursorPosition = {
-  line: number;      // 0-indexed line number
+  line: number; // 0-indexed line number
   character: number; // 0-indexed character offset within line
 };
 
@@ -90,6 +90,17 @@ export type ConnectionStatsResponse = {
   time: Date;
 };
 
+export type ConnectionInfo = {
+  id: string;
+  label: string;
+};
+
+export type ConnectionsListResult = {
+  version: string;
+  'selected-connection-id': string | null;
+  connections: ConnectionInfo[];
+};
+
 export class HttpClient {
   constructor(private readonly onBuild?: (ast: Ast) => void) {}
 
@@ -123,6 +134,11 @@ export class HttpClient {
     };
   }
 
+  public async listConnections(): Promise<ConnectionsListResult | undefined> {
+    const res = await this.baseGet<{ result: ConnectionsListResult }>('connections');
+    return res?.result;
+  }
+
   private async post(path: string, body: object): Promise<Response | undefined> {
     const res = await fetch(`${getBaseUrl()}/api/v1/${path}`, {
       method: 'POST',
@@ -145,7 +161,10 @@ export class HttpClient {
   }
 
   public async prettify(expression: string, connectionId?: string): Promise<string> {
-    const response: Response | undefined = await this.post('build', this.withConnectionId({ expression }, connectionId));
+    const response: Response | undefined = await this.post(
+      'build',
+      this.withConnectionId({ expression }, connectionId),
+    );
     if (!response) {
       throw new Error('No response when trying to prettify');
     }
@@ -164,14 +183,21 @@ export class HttpClient {
   }
 
   public async sql(query: string, connectionId?: string): Promise<Response> {
-    const response = await this.post('sql', this.withConnectionId({ query: query.trim() }, connectionId));
+    const response = await this.post(
+      'sql',
+      this.withConnectionId({ query: query.trim() }, connectionId),
+    );
     if (!response) {
       throw new Error('No response when trying to execute SQL');
     }
     return response;
   }
 
-  public async build(expression: string, cursor?: CursorPosition, connectionId?: string): Promise<Response> {
+  public async build(
+    expression: string,
+    cursor?: CursorPosition,
+    connectionId?: string,
+  ): Promise<Response> {
     const body: { expression: string; cursor?: CursorPosition } = { expression };
     if (cursor) {
       body.cursor = cursor;
@@ -201,7 +227,10 @@ export class HttpClient {
   ): Promise<{ expressions: { expression: string; column: string }[]; ast: Ast }> {
     // Add trailing `|` explicitly for child expressions
     const x = `${expression} |`;
-    const response = await this.post('build', this.withConnectionId({ expression: x }, connectionId));
+    const response = await this.post(
+      'build',
+      this.withConnectionId({ expression: x }, connectionId),
+    );
     if (!response) {
       throw new Error('No response when trying to make child Expressions');
     }

--- a/store/global.store.ts
+++ b/store/global.store.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable } from 'mobx';
 import { lt } from 'semver';
-import { HttpClient } from './client';
+import { HttpClient, ConnectionInfo } from './client';
 import { Session, Theme } from './session';
 import { RequiredVersion } from '../constants';
 import { getUserPreference, setUserPreference, STORAGE_KEYS } from './preferences';
@@ -23,6 +23,7 @@ export class GlobalStore {
   version: string | undefined = undefined;
   requiresUpgrade = false;
   connectionColors: Record<string, string> = {};
+  connections: ConnectionInfo[] = [];
 
   get pineConnected() {
     return DevState.pineConnected ?? !!this.version;
@@ -137,6 +138,41 @@ export class GlobalStore {
     return this.connectionColors[connectionId] ?? '';
   };
 
+  getConnectionLabel = (connectionId: string): string => {
+    if (!connectionId) return '';
+    const conn = this.connections.find(c => c.id === connectionId);
+    return conn?.label ?? connectionId;
+  };
+
+  private pruneConnectionColors = (liveIds: string[]) => {
+    const live = new Set(liveIds);
+    let changed = false;
+    for (const id of Object.keys(this.connectionColors)) {
+      if (!live.has(id)) {
+        delete this.connectionColors[id];
+        changed = true;
+      }
+    }
+    if (changed) {
+      setUserPreference(STORAGE_KEYS.CONNECTION_COLORS, this.connectionColors);
+    }
+  };
+
+  refreshConnections = async (): Promise<ConnectionInfo[]> => {
+    const result = await client.listConnections();
+    if (!result) {
+      return this.connections;
+    }
+    this.connections = result.connections ?? [];
+    this.connections.forEach(c => this.assignConnectionColor(c.id));
+    this.pruneConnectionColors(this.connections.map(c => c.id));
+    if (result.version) {
+      this.version = result.version;
+    }
+    this.connection = result['selected-connection-id'] ?? '';
+    return this.connections;
+  };
+
   setConnectionColor = (connectionId: string, color: string) => {
     this.connectionColors[connectionId] = color;
     setUserPreference(STORAGE_KEYS.CONNECTION_COLORS, this.connectionColors);
@@ -147,7 +183,9 @@ export class GlobalStore {
     const used = new Set(Object.values(this.connectionColors));
     const color =
       CONNECTION_COLOR_PALETTE.find(c => !used.has(c)) ??
-      CONNECTION_COLOR_PALETTE[Object.keys(this.connectionColors).length % CONNECTION_COLOR_PALETTE.length];
+      CONNECTION_COLOR_PALETTE[
+        Object.keys(this.connectionColors).length % CONNECTION_COLOR_PALETTE.length
+      ];
     this.setConnectionColor(connectionId, color);
   };
 
@@ -223,11 +261,34 @@ export class GlobalStore {
     this.pineTableColorsEnabled = !this.pineTableColorsEnabled;
   }
 
-  getConnectionName = () => {
-    if (!this.connection) return '';
-    const length = this.connection.length;
-    const maxLength = 24;
-    return length > maxLength ? this.connection.substring(0, maxLength) + '...' : this.connection;
+  /**
+   * Select an existing server connection from the picker. Opens a new tab if the
+   * active tab has content; otherwise assigns the connection to the active tab.
+   */
+  selectConnection = async (connectionId: string) => {
+    const activeSession = this.sessions[this.activeSessionId];
+    if (!activeSession) {
+      return;
+    }
+    if (activeSession.connectionId === connectionId && this.connection === connectionId) {
+      return;
+    }
+    try {
+      const { id, version } = await client.useConnection(connectionId);
+      this.connection = id;
+      this.version = version ?? '0.0.0';
+      if (activeSession.expression.trim()) {
+        const session = this.createSession();
+        this.activeSessionId = session.id;
+      } else {
+        activeSession.connectionId = id;
+      }
+      await this.refreshConnections();
+    } catch (e) {
+      const message = (e as Error)?.message ?? 'Unknown error';
+      activeSession.message = `⚠ Failed to switch connection: ${message}`;
+      throw e;
+    }
   };
 
   connect = async (params: ConnectionParams): Promise<string> => {
@@ -246,7 +307,12 @@ export class GlobalStore {
 
     const activeSession = this.sessions[this.activeSessionId];
     if (activeSession) {
-      activeSession.connectionId = id;
+      if (activeSession.expression.trim()) {
+        const session = this.createSession();
+        this.activeSessionId = session.id;
+      } else {
+        activeSession.connectionId = id;
+      }
     }
     if (this.virtualSession) {
       this.virtualSession.connectionId = id;
@@ -255,6 +321,7 @@ export class GlobalStore {
     if (!this.onboardingServer) {
       this.onboardingServer = true;
     }
+    await this.refreshConnections();
     return id;
   };
 
@@ -279,7 +346,9 @@ export class GlobalStore {
    * This is the proper way to create a new tab in the UI.
    */
   addTab = () => {
+    const activeSession = this.sessions[this.activeSessionId];
     const session = this.createSession();
+    session.connectionId = activeSession?.connectionId || this.connection;
     this.activeSessionId = session.id;
   };
 
@@ -359,6 +428,8 @@ export class GlobalStore {
       if (lt(this.version, RequiredVersion)) {
         this.requiresUpgrade = true;
       }
+
+      await this.refreshConnections();
     } catch (e) {
       console.error('Failed to load connection metadata', e);
       this.connection = '';


### PR DESCRIPTION
## Related PR
https://github.com/beamlynx/pine-lang/pull/39

## Summary

Adds a connection picker dropdown in the header, integrates the new Pine `GET /api/v1/connections` endpoint, and improves multi-connection tab behavior so each tab can keep its own database while sharing a single Pine server session.

**Requires:** Pine server with the structured `GET /api/v1/connections` response ([companion PR in `pine-lang`](https://github.com/beamlynx/pine-lang/pull/39)).

## Changes
<img width="839" height="590" alt="image" src="https://github.com/user-attachments/assets/da2ee5d1-2ffb-4908-8388-c53fe1b1823f" />

### Connection picker (`ActiveConnection`)

- Clicking the connection caption opens a **dropdown menu** instead of the database settings modal.
- Menu lists live connections from Pine with **`label`** (e.g. `localhost:5432 · myapp_dev`) and color dots.
- **Add new connection…** opens the existing settings modal.

### Connection list sync (`GlobalStore`, `HttpClient`)

- `listConnections()` — calls `GET /api/v1/connections`.
- `refreshConnections()` — updates `global.connections`, assigns colors for new ids, and **prunes stale entries** from `connectionColors` in localStorage when ids are no longer on the server.
- Refreshed on **page load**, after **connect**, and after **switch** (not on every menu open).

### Tab and connection assignment rules

| Action                         | Behavior                                                                                                                                         |
| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
| **Add connection** (settings)  | If active tab has a pine/SQL **expression** → **new tab**. Otherwise assign to active tab.                                                       |
| **Pick connection** (dropdown) | If active tab has a pine/SQL **expression** → **new tab**. If empty → **reuse active tab** and change its connection via **`selectConnection`**. |
| **+ new tab**                  | New empty tab inherits the **active tab’s** `connectionId` (not Pine’s global default).                                                          |

### UI polish

- Pine **version** moved to the top-right next to `[Development]` / user box.
- Active tab underline uses the tab’s **connection color** instead of `--primary-color`.
