### PR TITLE
Release 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [0.43.0] - 2026-05-21
 ### Added
-- Connection picker in each tab: click the connection dot to switch which database that tab queries.
+- Connection picker in each tab: click the connection dot to switch which database that tab queries (by @Koziar).
 
 ### Breaking
 - Minimum required server version is now `0.36.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-05-21
+### Added
+- Connection picker in each tab: click the connection dot to switch which database that tab queries.
+
+### Breaking
+- Minimum required server version is now `0.36.0`.
+
 ## [0.42.0] - 2026-05-05
 ### Added
 - Per-session database connections: each tab can connect to a different database. Queries from that tab always use its own connection.

--- a/constants.ts
+++ b/constants.ts
@@ -15,7 +15,7 @@ export const MIN_SIDEBAR_SECOND_VIEW_HEIGHT = 120;
 export const MAX_SIDEBAR_SECOND_VIEW_HEIGHT = 800;
 
 /* Pine Server */
-export const RequiredVersion = '0.35.0';
+export const RequiredVersion = '0.36.0';
 
 /* Layout Constants */
 // Height calculations for main content areas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -19,7 +19,7 @@ export const CHANGELOG: ChangelogVersion[] = [
     date: '2026-05-21',
     added: [
       {
-        description: 'Connection picker in each tab: click the connection dot to switch which database that tab queries.',
+        description: 'Connection picker in each tab: click the connection dot to switch which database that tab queries (by @Koziar).',
       },
     ],
     breaking: [

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,20 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.43.0',
+    date: '2026-05-21',
+    added: [
+      {
+        description: 'Connection picker in each tab: click the connection dot to switch which database that tab queries.',
+      },
+    ],
+    breaking: [
+      {
+        description: 'Minimum required server version is now `0.36.0`.',
+      },
+    ],
+  },
+  {
     version: '0.42.0',
     date: '2026-05-05',
     added: [
@@ -885,4 +899,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.42.0';
+export const LATEST_VERSION = '0.43.0';


### PR DESCRIPTION
Adds a connection picker to each tab (by @Koziar). Clicking the connection dot in a tab now opens a dropdown listing all registered connections, letting the user switch which database that tab queries without affecting other tabs.

Bumps `RequiredVersion` to `0.36.0` because the picker relies on the new structured `GET /api/v1/connections` endpoint introduced in pine-lang 0.36.0.