### PR TITLE
Release 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.45.0] - 2026-08-02
 ### Added
 - Support for a `NEXT_DESKTOP`/`NEXT_PUBLIC_DESKTOP`-gated static export build, used by the new `beamlynx-desktop` Electron app so the UI can run bundled with a local pine-lang server instead of pointed at a Docker container. No change to the hosted build.
 - Desktop-only keybindings: `Ctrl/Cmd+K` for the Command Palette, `Ctrl/Cmd+T` for New Tab, `Ctrl/Cmd+W` for Close Tab (`utils/keybindings.ts`). Unbound in the browser build, where the host browser already owns those combos -- the Command Palette shortcut stays `Ctrl/Cmd+Shift+P` there, same as before.
 - `DesktopUpdateBanner`: shows Electron's auto-update progress in-app ("Downloading update... NN%", then "Update ready -- Restart to install") instead of it being silent/console-only. Reads `beamlynx-desktop`'s new `window.beamlynxDesktop` preload API (`desktop.d.ts`); renders nothing in the browser build or in a desktop dev-server run without the real Electron preload.
+- In the desktop app, connections you add are now saved on your device (encrypted via the OS's own credential storage) and reloaded the next time you open the app, instead of only lasting for the current session. The connection picker's delete action now also forgets the saved connection, in addition to closing it. No change to the hosted/browser build, which still never stores credentials.
 
 ### Changed
 - The connected server's version chip (e.g. `[0.37.0]`) is now hidden when running in the desktop app -- it isn't beamlynx-ui's own version, and desktop users have their own release notes instead. Still shown in the browser/hosted build.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,34 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.45.0',
+    date: '2026-08-02',
+    added: [
+      {
+        description:
+          'Support for a `NEXT_DESKTOP`/`NEXT_PUBLIC_DESKTOP`-gated static export build, used by the new `beamlynx-desktop` Electron app so the UI can run bundled with a local pine-lang server instead of pointed at a Docker container. No change to the hosted build.',
+      },
+      {
+        description:
+          'Desktop-only keybindings: `Ctrl/Cmd+K` for the Command Palette, `Ctrl/Cmd+T` for New Tab, `Ctrl/Cmd+W` for Close Tab. Unbound in the browser build, where the host browser already owns those combos -- the Command Palette shortcut stays `Ctrl/Cmd+Shift+P` there, same as before.',
+      },
+      {
+        description:
+          "Auto-update progress is now shown in-app (\"Downloading update... NN%\", then \"Update ready -- Restart to install\") instead of it being silent/console-only, in the desktop app.",
+      },
+      {
+        description:
+          "In the desktop app, connections you add are now saved on your device (encrypted via the OS's own credential storage) and reloaded the next time you open the app, instead of only lasting for the current session. The connection picker's delete action now also forgets the saved connection, in addition to closing it. No change to the hosted/browser build, which still never stores credentials.",
+      },
+    ],
+    changed: [
+      {
+        description:
+          "The connected server's version chip (e.g. `[0.37.0]`) is now hidden when running in the desktop app -- it isn't beamlynx-ui's own version, and desktop users have their own release notes instead. Still shown in the browser/hosted build.",
+      },
+    ],
+  },
+  {
     version: '0.44.0',
     date: '2026-07-31',
     added: [
@@ -946,4 +974,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.44.0';
+export const LATEST_VERSION = '0.45.0';


### PR DESCRIPTION
This release bundles everything that's landed since 0.44.0 for the new desktop app, plus the desktop credential persistence work:

- Desktop app support: a `NEXT_PUBLIC_DESKTOP`-gated static export build, desktop-only keybindings, in-app auto-update progress banner.
- Connections you create in the desktop app are now saved on your device (encrypted via the OS's own credential storage) and reloaded next time you open the app, instead of only lasting for the session. Deleting a connection now also forgets the saved one, not just the active session. The hosted/browser build is unchanged -- it still never stores credentials.
- No new minimum pine-lang server version required by any of this.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `next lint` clean (pre-existing warnings only, unrelated to this change)
- [x] Manually verified on Linux (Hyprland): saved connections persist across an app restart, encrypted via the OS keyring, and the connection picker reloads them.