### PR TITLE
Release 0.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.45.1] - 2026-08-02
+### Fixed
+- In the desktop app, saved connections weren't showing their color or proper name in the connection picker.
+- The "Database Connection" dialog no longer pops up automatically when you already have saved or active connections to pick from -- it now only does that when there's genuinely nothing to connect to yet.
+
+### Changed
+- The notification bell no longer shakes when there's something new -- it still changes color, just more subtly.
+
 ## [0.45.0] - 2026-08-02
 ### Added
 - Beamlynx can now be downloaded and run as a desktop app, with no Docker required.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,26 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.45.1',
+    date: '2026-08-02',
+    fixed: [
+      {
+        description:
+          'In the desktop app, saved connections weren\'t showing their color or proper name in the connection picker.',
+      },
+      {
+        description:
+          'The "Database Connection" dialog no longer pops up automatically when you already have saved or active connections to pick from -- it now only does that when there\'s genuinely nothing to connect to yet.',
+      },
+    ],
+    changed: [
+      {
+        description:
+          "The notification bell no longer shakes when there's something new -- it still changes color, just more subtly.",
+      },
+    ],
+  },
+  {
     version: '0.45.0',
     date: '2026-08-02',
     added: [
@@ -972,4 +992,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.45.0';
+export const LATEST_VERSION = '0.45.1';


### PR DESCRIPTION
Follow-up fixes from testing the desktop credential-persistence release:

- Saved connections in the desktop app weren't showing their color or proper name in the picker (an id-mismatch between pine-server's own connection id and the saved profile's id).
- The connection dialog no longer auto-opens on load if you already have connections to pick from.
- The notification bell no longer shakes -- it still changes color for unread updates, just more subtly.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `next lint` clean (pre-existing warnings only, unrelated to this change)