### PR TITLE
Release 0.45.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.45.2] - 2026-08-02
+### Fixed
+- The notification bell's color (for unread updates) was showing as blue instead of the intended warm accent.
+
 ## [0.45.1] - 2026-08-02
 ### Fixed
 - In the desktop app, saved connections weren't showing their color or proper name in the connection picker.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,16 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.45.2',
+    date: '2026-08-02',
+    fixed: [
+      {
+        description:
+          "The notification bell's color (for unread updates) was showing as blue instead of the intended warm accent.",
+      },
+    ],
+  },
+  {
     version: '0.45.1',
     date: '2026-08-02',
     fixed: [
@@ -992,4 +1002,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.45.1';
+export const LATEST_VERSION = '0.45.2';


### PR DESCRIPTION
Small follow-up: the notification bell's color for unread updates was showing as blue (an accidental reuse of the primary accent color) instead of the intended warm tangerine.

## Test plan
- [x] `tsc --noEmit` clean