### PR TITLE
Release 0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-08-03
+### Added
+- Tabs (Pine/SQL text, input mode, connection) are now restored on reload instead of always starting from a single blank session.
+- `Ctrl/Cmd+S` ("Save Tab") downloads the active tab's Pine expression as a `.pine` file.
+- New "List Database Connections" / "New Database Connection" command palette entries.
+
+### Fixed
+- Pressing Tab while the graph had focus was falling through to React Flow's own node/edge navigation instead of cycling through Pine completion candidates.
+
 ## [0.45.2] - 2026-08-02
 ### Fixed
 - The notification bell's color (for unread updates) was showing as blue instead of the intended warm accent.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.45.2",
+  "version": "0.46.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,30 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.46.0',
+    date: '2026-08-03',
+    added: [
+      {
+        description:
+          'Tabs (Pine/SQL text, input mode, connection) are now restored on reload instead of always starting from a single blank session.',
+      },
+      {
+        description:
+          "`Ctrl/Cmd+S` (\"Save Tab\") downloads the active tab's Pine expression as a `.pine` file.",
+      },
+      {
+        description:
+          'New "List Database Connections" / "New Database Connection" command palette entries.',
+      },
+    ],
+    fixed: [
+      {
+        description:
+          "Pressing Tab while the graph had focus was falling through to React Flow's own node/edge navigation instead of cycling through Pine completion candidates.",
+      },
+    ],
+  },
+  {
     version: '0.45.2',
     date: '2026-08-02',
     fixed: [
@@ -1002,4 +1026,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.45.2';
+export const LATEST_VERSION = '0.46.0';


### PR DESCRIPTION
Tabs now survive a reload -- their Pine/SQL text, input mode, and connection are restored instead of always starting blank. You can also save the active tab's Pine expression to a `.pine` file with Ctrl/Cmd+S, and manage database connections straight from the command palette ("List Database Connections" / "New Database Connection").

Also fixes a keyboard bug where pressing Tab while the graph had focus would jump into React Flow's own node/edge navigation instead of cycling through Pine completion candidates like it does everywhere else.