### PR TITLE
Release 0.46.1: playground connection delete-guard, changelog date fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.46.1] - 2026-08-03
+### Fixed
+- The playground's shared connection could be deleted from the connection picker, breaking the playground for everyone else using it; the delete action is now hidden (and refused as a backstop) in playground mode.
+- The changelog's relative-date label showed "-1 days ago" for a same-day entry when the local timezone is behind UTC.
+
 ## [0.46.0] - 2026-08-03
 ### Added
 - Tabs (Pine/SQL text, input mode, connection) are now restored on reload instead of always starting from a single blank session.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,20 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.46.1',
+    date: '2026-08-03',
+    fixed: [
+      {
+        description:
+          "The playground's shared connection could be deleted from the connection picker, breaking the playground for everyone else using it; the delete action is now hidden (and refused as a backstop) in playground mode.",
+      },
+      {
+        description:
+          'The changelog\'s relative-date label showed "-1 days ago" for a same-day entry when the local timezone is behind UTC.',
+      },
+    ],
+  },
+  {
     version: '0.46.0',
     date: '2026-08-03',
     added: [
@@ -1026,4 +1040,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.46.0';
+export const LATEST_VERSION = '0.46.1';


### PR DESCRIPTION
## Summary
- The playground's shared connection could be deleted from the connection picker, breaking the playground for everyone else using it. The delete action is now hidden (and refused as a backstop) in playground mode.
- The changelog's relative-date label showed "-1 days ago" for a same-day entry when the local timezone is behind UTC. Fixed by treating any non-positive day diff as "Today".

## Test plan
- [ ] Confirm the delete icon is hidden in the connection picker when running against the playground host
- [ ] Confirm connections can still be deleted normally outside playground mode
- [ ] Confirm the changelog modal shows "Today" for the 0.46.1 entry instead of "-1 days ago"