### PR TITLE
Release 0.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.46.2] - 2026-08-04
+### Breaking
+- Requires pine-lang 0.37.2 or later.
+
+### Fixed
+- A failed attempt to connect (unreachable DB, wrong credentials, etc.) used to fail silently — the toolbar just stopped showing a "connecting" spinner with no indication anything went wrong. A new error toast now surfaces the actual failure.
+- A previously-used connection restored from a past session could show as "connected" in the toolbar even when nothing was actually connected this session (pine-server's connection pools don't survive a process restart). Restored connections are now checked against the backend's live state before being trusted.
+- When disconnected, the app now automatically opens the connections picker (or the add-connection form, if none exist yet) instead of leaving a dead "Not connected to database" label with no obvious next step.
+
 ## [0.46.1] - 2026-08-03
 ### Fixed
 - The playground's shared connection could be deleted from the connection picker, breaking the playground for everyone else using it; the delete action is now hidden (and refused as a backstop) in playground mode.

--- a/constants.ts
+++ b/constants.ts
@@ -15,7 +15,7 @@ export const MIN_SIDEBAR_SECOND_VIEW_HEIGHT = 120;
 export const MAX_SIDEBAR_SECOND_VIEW_HEIGHT = 800;
 
 /* Pine Server */
-export const RequiredVersion = '0.37.0';
+export const RequiredVersion = '0.37.2';
 
 /* Layout Constants */
 // Height calculations for main content areas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,29 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.46.2',
+    date: '2026-08-04',
+    breaking: [
+      {
+        description: 'Requires pine-lang 0.37.2 or later.',
+      },
+    ],
+    fixed: [
+      {
+        description:
+          'A failed attempt to connect (unreachable DB, wrong credentials, etc.) used to fail silently — the toolbar just stopped showing a "connecting" spinner with no indication anything went wrong. A new error toast now surfaces the actual failure.',
+      },
+      {
+        description:
+          "A previously-used connection restored from a past session could show as \"connected\" in the toolbar even when nothing was actually connected this session (pine-server's connection pools don't survive a process restart). Restored connections are now checked against the backend's live state before being trusted.",
+      },
+      {
+        description:
+          'When disconnected, the app now automatically opens the connections picker (or the add-connection form, if none exist yet) instead of leaving a dead "Not connected to database" label with no obvious next step.',
+      },
+    ],
+  },
+  {
     version: '0.46.1',
     date: '2026-08-03',
     fixed: [
@@ -1040,4 +1063,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.46.1';
+export const LATEST_VERSION = '0.46.2';


### PR DESCRIPTION
Requires pine-lang 0.37.2 or later.

Fixes:

- A failed attempt to connect (unreachable DB, wrong credentials, etc.) used to fail silently. A new error toast now surfaces the actual failure.
- A previously-used connection restored from a past session could show as "connected" even when nothing was actually connected this session. Restored connections are now checked against the backend's live state before being trusted.
- When disconnected, the app now automatically opens the connections picker (or the add-connection form, if none exist yet) instead of leaving a dead "Not connected to database" label.