### PR TITLE
Release 0.48.1: fix desktop build failure from next/font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-08-14
+### Fixed
+- The desktop build failed outright ("assetPrefix must start with a leading slash...") because `next/font`'s self-hosted app font isn't compatible with the relative asset paths the desktop build needs for `file://` loading. The desktop build now falls back to a generic monospace stack instead of the self-hosted font in that one case.
+
 ## [0.48.0] - 2026-08-13
 ### Breaking
 - Requires pine-lang 0.38.1 or later.

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const isDesktop = process.env.NEXT_DESKTOP === '1';
 
 /** @type {import('next').NextConfig} */
@@ -9,6 +11,24 @@ const nextConfig = {
   // routes) 404 under file://. Gated behind an env flag so the hosted build
   // is unaffected.
   ...(isDesktop ? { output: 'export', assetPrefix: './', trailingSlash: true } : {}),
+  // next/font (styles/app-font.ts) validates this same relative assetPrefix
+  // at build time and fails the whole build the moment webpack parses it --
+  // swap in the desktop-safe stand-in (styles/app-font.desktop.ts) before
+  // webpack ever gets there, rather than trying to branch inside app-font.ts
+  // itself (next/font requires its call to be an unconditional, static
+  // `const` at module scope -- a runtime/conditional check inside that file
+  // doesn't stop its compiler plugin from still parsing and rejecting it).
+  ...(isDesktop
+    ? {
+        webpack: config => {
+          config.resolve.alias[path.resolve(__dirname, 'styles/app-font')] = path.resolve(
+            __dirname,
+            'styles/app-font.desktop.ts',
+          );
+          return config;
+        },
+      }
+    : {}),
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/styles/app-font.desktop.ts
+++ b/styles/app-font.desktop.ts
@@ -1,0 +1,9 @@
+// Desktop build's stand-in for app-font.ts - webpack-aliased in by
+// next.config.js instead of the real file, which next/font can't compile
+// under the desktop build's relative `assetPrefix` (see app-font.ts's own
+// comment for why). `.canvas-font-fallback` (styles/globals.css) defines
+// the real --canvas-font variable, just pointing at a generic monospace
+// stack instead of the self-hosted IBM Plex Mono the hosted build gets -
+// purely cosmetic, nothing reads --canvas-font expecting this exact
+// typeface, only *a* monospace one.
+export const appFont = { variable: 'canvas-font-fallback' };

--- a/styles/app-font.ts
+++ b/styles/app-font.ts
@@ -14,6 +14,18 @@ import { IBM_Plex_Mono } from 'next/font/google';
 // DOM subtree - kept as `--canvas-font` (not renamed to something app-
 // generic) purely to avoid a second mechanical rename across every canvas
 // component that already reads it.
+//
+// The desktop build never actually loads this file - next.config.js
+// webpack-aliases this exact module path to app-font.desktop.ts instead,
+// because next/font validates `assetPrefix` at build time and rejects
+// anything that isn't a leading-slash path or an absolute URL. The desktop
+// build sets `assetPrefix: './'` (relative, so file://-loaded assets
+// resolve correctly), which trips that check and fails `next build`
+// outright the moment webpack so much as parses a next/font call - not
+// something a runtime/conditional check inside this file can work around,
+// since next/font's own compiler plugin requires "Font loaders must be
+// called and assigned to a const in module scope", i.e. unconditionally.
+// See app-font.desktop.ts for the substitute this file never gets to run.
 export const appFont = IBM_Plex_Mono({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,13 @@
+/* Desktop-build fallback for --canvas-font (see styles/app-font.ts) - the
+ * desktop build can't use next/font (its relative assetPrefix trips next/
+ * font's build-time validation), so it applies this class instead of
+ * next/font's own generated one, keeping --canvas-font defined everywhere
+ * that reads it, just pointing at a generic monospace stack rather than the
+ * self-hosted IBM Plex Mono the hosted build gets. */
+.canvas-font-fallback {
+  --canvas-font: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+}
+
 html,
 body {
   padding: 0;

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,6 +15,16 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
+    version: '0.48.1',
+    date: '2026-08-14',
+    fixed: [
+      {
+        description:
+          "The desktop build failed outright (\"assetPrefix must start with a leading slash...\") because next/font's self-hosted app font isn't compatible with the relative asset paths the desktop build needs for file:// loading. The desktop build now falls back to a generic monospace stack instead of the self-hosted font in that one case.",
+      },
+    ],
+  },
+  {
     version: '0.48.0',
     date: '2026-08-13',
     breaking: [
@@ -1127,4 +1137,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.48.0';
+export const LATEST_VERSION = '0.48.1';


### PR DESCRIPTION
## Summary
- The desktop build (\`NEXT_DESKTOP=1 next build\`) failed outright with "assetPrefix must start with a leading slash..." - next/font's self-hosted app font validates \`assetPrefix\` at build time, and the desktop build's relative one (needed so assets resolve correctly under \`file://\`) trips that check. Found while cutting beamlynx-desktop's 0.2.0 release.
- next/font requires its call to be an unconditional, static \`const\` at module scope, so this can't be worked around with a runtime/conditional check in the same file. Webpack now aliases the whole module to a plain-monospace stand-in for the desktop build only, before next/font ever parses it. The hosted build is unaffected - still gets the real self-hosted IBM Plex Mono.

## Test plan
- [x] \`npm run build\` (hosted) succeeds
- [x] \`NEXT_DESKTOP=1 npm run build\` (desktop static export) succeeds, output verified under \`out/\`
- [x] \`type-check\`/\`lint\` clean