### PR TITLE
docs: drop 0.48.1's changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [0.48.1] - 2026-08-14
-### Fixed
-- The desktop build failed outright ("assetPrefix must start with a leading slash...") because `next/font`'s self-hosted app font isn't compatible with the relative asset paths the desktop build needs for `file://` loading. The desktop build now falls back to a generic monospace stack instead of the self-hosted font in that one case.
-
 ## [0.48.0] - 2026-08-13
 ### Breaking
 - Requires pine-lang 0.38.1 or later.

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -15,16 +15,6 @@ export interface ChangelogVersion {
 
 export const CHANGELOG: ChangelogVersion[] = [
   {
-    version: '0.48.1',
-    date: '2026-08-14',
-    fixed: [
-      {
-        description:
-          "The desktop build failed outright (\"assetPrefix must start with a leading slash...\") because next/font's self-hosted app font isn't compatible with the relative asset paths the desktop build needs for file:// loading. The desktop build now falls back to a generic monospace stack instead of the self-hosted font in that one case.",
-      },
-    ],
-  },
-  {
     version: '0.48.0',
     date: '2026-08-13',
     breaking: [


### PR DESCRIPTION
## Summary
0.48.1 only existed to fix a desktop build failure (next/font + relative assetPrefix) in 0.48.0 - nothing about it was ever user-facing in a published release, so it doesn't belong in the changelog. Removes the entry from both CHANGELOG.md and changelog.data.ts. The version number itself is unaffected.