### PR TITLE
Release 0.48.2: give desktop a clean tag to pin to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pine-app",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/utils/changelog.data.ts
+++ b/utils/changelog.data.ts
@@ -1127,4 +1127,4 @@ export const CHANGELOG: ChangelogVersion[] = [
   },
 ];
 
-export const LATEST_VERSION = '0.48.1';
+export const LATEST_VERSION = '0.48.2';


### PR DESCRIPTION
## Summary
Purely a version bump, no CHANGELOG.md entry. 0.48.1's changelog fix (PR #42) landed on main *after* the 0.48.1 tag was already cut, so the actual tagged/bundled 0.48.1 artifact never included it - tags don't move. This gives beamlynx-desktop a clean tag to re-pin to.